### PR TITLE
Switch to pytest and add legacy flags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,17 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Test
+    - name: Test calculator
       run: |
-        coverage run -m unittest discover tests
+        coverage run -m pytest tests/test_calculator.py
+        coverage xml
     - uses: codecov/codecov-action@v1
+      with:
+        flags: calculator
+    - name: Test smiles
+      run: |
+        coverage run -m pytest tests/test_smiles.py
+        coverage xml
+    - uses: codecov/codecov-action@v1
+      with:
+        flags: smiles

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,25 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 50%
+      calculator:
+        target: 100%
+      smiles:
+        target: 75%
+    patch:
+      default:
+        target: 100%
+
+flags:
+  calculator:
+    paths:
+      - calculator/
+    carryforward: true
+  smiles:
+    paths:
+      - smiles/
+    carryforward: true
+
 ignore:
   - tests/*

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,12 @@ coverage:
         target: 50%
       calculator:
         target: 100%
+        flags:
+          - calculator
       smiles:
         target: 75%
+        flags:
+          - smiles
     patch:
       default:
         target: 100%

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 coverage==5.5
+pytest==6.2.3

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,15 +1,9 @@
-import unittest
-
 from calculator import calculator
 
 
-class TestMethods(unittest.TestCase):
-    def test_add(self):
-        self.assertEqual(calculator.add(1, 2), 3)
-
-    def test_subtract(self):
-        self.assertEqual(calculator.subtract(1, 2), -1)
+def test_add():
+    assert calculator.add(1, 2) == 3
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_subtract():
+    assert calculator.subtract(1, 2) == -1

--- a/tests/test_smiles.py
+++ b/tests/test_smiles.py
@@ -1,12 +1,5 @@
-import unittest
-
 from smiles import smiles
 
 
-class TestMethods(unittest.TestCase):
-    def test_smile(self):
-        self.assertEqual(smiles.smile(), ":)")
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_smile():
+    assert smiles.smile() == ":)"


### PR DESCRIPTION
This commits switches from using `unittest` to `pytest`. We also add two bespoke (legacy) flags:
- `calculator`
- `smiles`
which corresponds to each directory. 

In order to make bespoke flags work, we have added `flags` and `coverage -> status` sections to the `codecov.yml`. We also upload each coverage report with its own flag. To get more details on bespoke flags, check out our [documentation](https://docs.codecov.io/docs/flags#advanced-bespoke-flag-management)